### PR TITLE
Fix C4 architecture accuracy and test gaps

### DIFF
--- a/docs/architecture/model.c4
+++ b/docs/architecture/model.c4
@@ -41,13 +41,15 @@ model {
         #core, #reactive
         description '''
           Reactive state container extending EventTarget. Holds
-          editor-wide state: active tool, active layer, selected
-          tile GID, tilemap reference, viewport pan/zoom. Dispatches
+          editor-wide state: active tool, active layer index,
+          selected tile GID, and tilemap reference. Dispatches
           'editor-state-change' CustomEvents when properties change.
           Currently the EditorShell orchestrator passes props down
-          to children rather than children subscribing directly.
-          Core models are plain data; the store provides typed
-          getters/setters with change notification.
+          to children rather than children subscribing directly —
+          the store is written to by the shell but not yet read
+          by child components. Viewport pan/zoom fields exist on
+          the store but are not currently written to; viewport
+          state lives inside MapCanvas.
         '''
         technology 'TypeScript'
       }
@@ -115,10 +117,11 @@ model {
         description '''
           Stateless tool strategies dispatched via a strategy
           registry. Each tool receives (ToolEvent, EditorState,
-          TilemapModel) and returns a Command object for undo/redo.
-          Implements: brush, eraser, bucket fill (BFS), eyedropper.
-          No internal state — active tool identity lives in
-          Editor Store.
+          TilemapModel) and returns a Command or null. Brush,
+          eraser, and fill return PaintCommands for undo/redo.
+          Eyedropper returns null and signals via a callback
+          (onEyedrop) in EditorState. Called inline by MapCanvas
+          which constructs EditorState from its own properties.
         '''
         technology 'TypeScript'
       }
@@ -130,8 +133,9 @@ model {
           (cell edits), AddLayerCommand, DeleteLayerCommand,
           ReorderLayerCommand, and RenameLayerCommand. Fixed-size
           stack bounded by both command count (100) and byte size
-          (10MB). Extends EventTarget, dispatches history-change
-          events for UI reactivity.
+          (10MB). Extends EventTarget and dispatches history-change
+          events (currently unused — shell calls requestUpdate()
+          directly after undo/redo operations).
         '''
         technology 'TypeScript'
       }
@@ -156,8 +160,10 @@ model {
           interactions (click/drag painting). Uses viewport
           culling (only renders tiles within the visible region).
           Renders visible layers with per-layer opacity via
-          Canvas 2D API. Emits bs-paint, bs-viewport-change,
-          and bs-cell-hover events to the parent shell.
+          Canvas 2D API. Calls ToolEngine dispatch() inline
+          and emits bs-paint, bs-paint-end, bs-eyedrop,
+          bs-viewport-change, and bs-cell-hover events to the
+          parent shell.
         '''
         technology 'Lit 3, Canvas API'
       }
@@ -188,10 +194,13 @@ model {
 
       toolbar = component 'Toolbar' {
         description '''
-          Tool selection (brush, eraser, fill, select, etc.),
-          undo/redo buttons, zoom controls, save/export triggers.
+          Rendered inline in EditorShell using bh-toolbar — not
+          a standalone component. Provides tool selection (brush,
+          eraser, fill, eyedropper), undo/redo buttons, and
+          save/export triggers. Tool state and keyboard shortcuts
+          (B/E/G/I, Ctrl+Z/Ctrl+Shift+Z) handled by the shell.
         '''
-        technology 'Lit 3'
+        technology 'Lit 3 (inline in EditorShell)'
       }
 
       importDialog = component 'Import Dialog' {
@@ -223,10 +232,8 @@ model {
   // EditorShell (bs-editor-shell) orchestrates all components,
   // passing props down and listening to events bubbling up.
 
-  // Editor Store — state container (data holder, not reactive hub yet)
-  editorStore -> tilesetModel 'holds reference to'
+  // Editor Store — state container (written by shell, not yet read by children)
   editorStore -> tilemapModel 'holds reference to'
-  editorStore -> selectionModel 'holds reference to'
 
   // Tilemap owns layers
   tilemapModel -> layerModel 'contains ordered stack of'
@@ -257,8 +264,9 @@ model {
   layerPanel -> layerModel 'displays layer stack from'
   layerPanel -> editorStore 'shell updates active layer on bs-layer-select'
 
-  // History — shell mediates between canvas/toolbar and HistoryManager
-  toolEngine -> historyManager 'shell pushes commands from completed strokes'
+  // History — shell mediates between canvas/toolbar and HistoryManager.
+  // Canvas emits bs-paint/bs-paint-end; shell accumulates edits and pushes to history.
+  mapCanvas -> historyManager 'shell pushes commands from completed strokes on bs-paint-end'
   toolbar -> historyManager 'shell triggers undo/redo on click or Ctrl+Z'
   historyManager -> tilemapModel 'restores previous cell values on undo/redo'
 

--- a/docs/architecture/views.c4
+++ b/docs/architecture/views.c4
@@ -68,9 +68,9 @@ views {
     description '''
       Internal structure of the editor application. Core domain
       models (green) are pure TypeScript with no UI dependency.
-      The Editor Store (amber) is the reactive state hub. UI
-      components (blue) subscribe to the store and dispatch
-      mutations through the domain models.
+      The Editor Store (amber) holds state written by the shell.
+      UI components (blue) receive props from the shell and emit
+      events upward; the shell orchestrates all mutations.
     '''
 
     include *
@@ -169,9 +169,9 @@ views {
     gamedev -> backsplash.editorApp.importDialog 'confirms tile size'
     backsplash.editorApp.importDialog -> backsplash.editorApp.tilesetModel 'shell creates tileset on bs-import-confirm'
 
-    // Shell adds tileset to tilemap and triggers Lit re-render;
+    // Shell adds tileset to tilemap via tilemap.addTileset(tileset);
     // tilesetPanel receives updated tilesets via props
-    backsplash.editorApp.tilesetModel -> backsplash.editorApp.tilemapModel 'shell calls addTileset'
+    backsplash.editorApp.tilemapModel -> backsplash.editorApp.tilesetModel 'shell registers tileset via tilemap.addTileset'
     backsplash.editorApp.tilesetPanel -> backsplash.editorApp.tilesetModel 'reads updated tilesets via props'
   }
 
@@ -201,11 +201,12 @@ views {
     gamedev -> backsplash.editorApp.mapCanvas 'clicks/drags on map cell'
     backsplash.editorApp.mapCanvas -> backsplash.editorApp.toolEngine 'dispatches pointer event with cell coords and EditorState'
 
-    // Tool engine applies mutation
+    // Tool engine applies mutation (called inline by canvas)
     backsplash.editorApp.toolEngine -> backsplash.editorApp.tilemapModel 'writes GID to cell on active layer'
 
-    // Shell records stroke in history on pointer up
-    backsplash.editorApp.toolEngine -> backsplash.editorApp.historyManager 'shell batches stroke edits into one command'
+    // Canvas emits bs-paint events; shell accumulates edits.
+    // On bs-paint-end (pointer up), shell pushes one PaintCommand to history.
+    backsplash.editorApp.mapCanvas -> backsplash.editorApp.historyManager 'shell batches stroke edits into one command on bs-paint-end'
 
     // Canvas re-renders
     backsplash.editorApp.mapCanvas -> backsplash.editorApp.tilesetModel 'fetches tile image for painted GID'
@@ -227,7 +228,7 @@ views {
     backsplash.editorApp.mapCanvas -> backsplash.editorApp.toolEngine 'dispatches pointer event with cell coords'
 
     backsplash.editorApp.toolEngine -> backsplash.editorApp.tilemapModel 'BFS flood fills contiguous cells with selected GID'
-    backsplash.editorApp.toolEngine -> backsplash.editorApp.historyManager 'shell pushes batch PaintCommand'
+    backsplash.editorApp.mapCanvas -> backsplash.editorApp.historyManager 'shell pushes batch PaintCommand on bs-paint-end'
 
     backsplash.editorApp.mapCanvas -> backsplash.editorApp.tilesetModel 'fetches tile images for filled region'
   }

--- a/src/models/tilemap-model.test.ts
+++ b/src/models/tilemap-model.test.ts
@@ -197,6 +197,25 @@ describe('TilemapModel — layer stack', () => {
     expect(map.layers[0].name).toBe('Layer 1');
   });
 
+  it('replaceLayer swaps the layer at the given index', () => {
+    const map = makeMap();
+    map.addLayer(createTileLayer('Layer 2', 10, 8));
+    const replacement = createTileLayer('Replaced', 10, 8);
+    map.replaceLayer(0, replacement);
+    expect(map.layers[0].name).toBe('Replaced');
+    expect(map.layers[1].name).toBe('Layer 2');
+    expect(map.layers).toHaveLength(2);
+  });
+
+  it('replaceLayer is a no-op for out-of-range index', () => {
+    const map = makeMap();
+    const replacement = createTileLayer('Nope', 10, 8);
+    map.replaceLayer(5, replacement);
+    map.replaceLayer(-1, replacement);
+    expect(map.layers).toHaveLength(1);
+    expect(map.layers[0].name).toBe('Layer 1');
+  });
+
   it('can add object layers to the stack', () => {
     const map = makeMap();
     map.addLayer(createObjectLayer('Objects'));


### PR DESCRIPTION
## Summary

- Fix 9 C4 architecture inaccuracies found by agent review (accumulated drift from M1–M5)
- Add 2 new `replaceLayer` tests to tilemap-model.test.ts (331 total tests)

### C4 fixes

| # | Fix |
|---|-----|
| 1 | `editorStore` — clarify viewport fields unused, store is write-only |
| 2 | Remove false `editorStore->selectionModel` relationship |
| 3 | `toolEngine` — eyedropper returns null, canvas builds EditorState |
| 4 | `mapCanvas` — add missing `bs-paint-end` and `bs-eyedrop` events |
| 5 | `historyManager` — history-change events currently unused |
| 6 | `toolbar` — rendered inline in EditorShell, not standalone |
| 7 | `paintFlow`/`fillFlow` — history mediated by canvas/shell, not ToolEngine |
| 8 | `importFlow` — fix tilesetModel->tilemapModel arrow direction |
| 9 | Component view description — shell orchestrates props, not reactive hub |

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npx vitest run` passes (331 tests, 11 files)
- [x] All C4 descriptions verified against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)